### PR TITLE
Refresh dashboard UI with modular layout components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 *.pycache
 .DS_Store
 .env
+frontend/node_modules/
+frontend/dist/

--- a/frontend/src/components/HeroPanel.jsx
+++ b/frontend/src/components/HeroPanel.jsx
@@ -1,0 +1,73 @@
+import PropTypes from 'prop-types';
+
+export default function HeroPanel({
+  stats,
+  description,
+  systemStatus,
+  onRunGlobal,
+  onRunAnnual,
+  onRefresh,
+  running,
+  loading
+}) {
+  return (
+    <section className="hero-panel">
+      <div className="hero-panel__content">
+        <h2>Monitoreo de floraciones y vegetación</h2>
+        <p>{description}</p>
+
+        <div className="hero-panel__actions">
+          <button type="button" onClick={onRunGlobal} disabled={running}>
+            {running ? 'Procesando…' : 'Recalcular (umbral global)'}
+          </button>
+          <button type="button" onClick={onRunAnnual} disabled={running}>
+            {running ? 'Procesando…' : 'Recalcular (umbral anual)'}
+          </button>
+          <button type="button" onClick={onRefresh} disabled={loading} className="button--ghost">
+            {loading ? 'Actualizando…' : 'Actualizar resumen'}
+          </button>
+        </div>
+      </div>
+
+      <aside className="hero-panel__status" aria-label="Estado del sistema">
+        <div className="hero-panel__status-card">
+          <p className="hero-panel__status-label">Estado del sistema</p>
+          <p className="hero-panel__status-value">{systemStatus.title}</p>
+          <p className="hero-panel__status-hint">{systemStatus.hint}</p>
+        </div>
+      </aside>
+
+      <div className="hero-panel__stats">
+        {stats.map((stat) => (
+          <div key={stat.label} className="hero-panel__stat">
+            {stat.card}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+HeroPanel.propTypes = {
+  stats: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      card: PropTypes.node.isRequired
+    })
+  ).isRequired,
+  description: PropTypes.string.isRequired,
+  systemStatus: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    hint: PropTypes.string.isRequired
+  }).isRequired,
+  onRunGlobal: PropTypes.func.isRequired,
+  onRunAnnual: PropTypes.func.isRequired,
+  onRefresh: PropTypes.func.isRequired,
+  running: PropTypes.bool,
+  loading: PropTypes.bool
+};
+
+HeroPanel.defaultProps = {
+  running: false,
+  loading: false
+};

--- a/frontend/src/components/MenuActions.jsx
+++ b/frontend/src/components/MenuActions.jsx
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+
+export default function MenuActions({ menu, loading, error, onRefresh }) {
+  if (loading) {
+    return <p className="status">Consultando menú…</p>;
+  }
+
+  if (error) {
+    return (
+      <div className="status status--error">
+        <p>No se pudo cargar el menú ({error}).</p>
+        <button type="button" onClick={onRefresh} className="button--ghost">Reintentar</button>
+      </div>
+    );
+  }
+
+  if (!menu?.length) {
+    return <p className="status">No hay comandos registrados.</p>;
+  }
+
+  return (
+    <div className="menu-actions">
+      {menu.map((item) => (
+        <article key={item.key} className="menu-actions__item">
+          <header>
+            <span className="menu-actions__key">{item.key}</span>
+            <h3>{item.label}</h3>
+          </header>
+          <p>{item.description}</p>
+          {item.parameters?.length ? (
+            <ul className="menu-actions__params">
+              {item.parameters.map((param) => (
+                <li key={param.name}>
+                  <code>{param.name}</code>
+                  <span>{param.required ? 'Requerido' : 'Opcional'} · {param.description}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          <div className="menu-actions__buttons">
+            <button type="button" disabled>
+              <span aria-hidden="true">▶</span> Ejecutar
+            </button>
+            <button type="button" className="button--ghost" onClick={onRefresh}>
+              <span aria-hidden="true">↻</span> Actualizar
+            </button>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+MenuActions.propTypes = {
+  menu: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      parameters: PropTypes.arrayOf(
+        PropTypes.shape({
+          name: PropTypes.string.isRequired,
+          required: PropTypes.bool,
+          description: PropTypes.string
+        })
+      )
+    })
+  ),
+  loading: PropTypes.bool,
+  error: PropTypes.string,
+  onRefresh: PropTypes.func
+};
+
+MenuActions.defaultProps = {
+  menu: [],
+  loading: false,
+  error: null,
+  onRefresh: () => {}
+};

--- a/frontend/src/components/StatCard.jsx
+++ b/frontend/src/components/StatCard.jsx
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+
+export default function StatCard({ icon, label, value, hint, tone }) {
+  return (
+    <article className={`stat-card stat-card--${tone}`}>
+      <span className="stat-card__icon" aria-hidden="true">{icon}</span>
+      <div>
+        <p className="stat-card__label">{label}</p>
+        <p className="stat-card__value">{value}</p>
+        {hint ? <p className="stat-card__hint">{hint}</p> : null}
+      </div>
+    </article>
+  );
+}
+
+StatCard.propTypes = {
+  icon: PropTypes.node.isRequired,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  hint: PropTypes.string,
+  tone: PropTypes.oneOf(['emerald', 'sky', 'slate', 'amber'])
+};
+
+StatCard.defaultProps = {
+  hint: undefined,
+  tone: 'emerald'
+};

--- a/frontend/src/components/layout/DashboardFooter.jsx
+++ b/frontend/src/components/layout/DashboardFooter.jsx
@@ -1,0 +1,10 @@
+export default function DashboardFooter() {
+  return (
+    <footer className="dashboard-footer">
+      <p>
+        BloomWatch · UI adaptada para exploración ambiental.<br />
+        Datos simulados mostrados únicamente con fines de diseño.
+      </p>
+    </footer>
+  );
+}

--- a/frontend/src/components/layout/DashboardHeader.jsx
+++ b/frontend/src/components/layout/DashboardHeader.jsx
@@ -1,0 +1,31 @@
+export default function DashboardHeader() {
+  const navItems = [
+    { label: 'Mapa', symbol: '🗺️' },
+    { label: 'Series', symbol: '📊' },
+    { label: 'Predicción', symbol: '🎯' },
+    { label: 'Galería', symbol: '🖼️' }
+  ];
+
+  return (
+    <header className="dashboard-header">
+      <div className="dashboard-header__brand">
+        <span className="dashboard-header__logo">
+          <span aria-hidden="true">🌿</span>
+        </span>
+        <div>
+          <h1>BloomWatch</h1>
+          <p>Monitoreo ambiental de floraciones y vegetación.</p>
+        </div>
+      </div>
+
+      <nav className="dashboard-header__nav" aria-label="Secciones principales">
+        {navItems.map(({ label, symbol }) => (
+          <button type="button" key={label} className="dashboard-header__nav-item">
+            <span aria-hidden="true">{symbol}</span>
+            <span>{label}</span>
+          </button>
+        ))}
+      </nav>
+    </header>
+  );
+}

--- a/frontend/src/components/layout/DashboardSection.jsx
+++ b/frontend/src/components/layout/DashboardSection.jsx
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types';
+
+export default function DashboardSection({ title, subtitle, icon, actions, children, fullWidth }) {
+  return (
+    <section className={`dashboard-section${fullWidth ? ' dashboard-section--wide' : ''}`}>
+      <header className="dashboard-section__head">
+        <div className="dashboard-section__title">
+          {icon ? <span className="dashboard-section__icon" aria-hidden="true">{icon}</span> : null}
+          <div>
+            <h2>{title}</h2>
+            {subtitle ? <p>{subtitle}</p> : null}
+          </div>
+        </div>
+        {actions ? <div className="dashboard-section__actions">{actions}</div> : null}
+      </header>
+      <div className="dashboard-section__content">{children}</div>
+    </section>
+  );
+}
+
+DashboardSection.propTypes = {
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
+  icon: PropTypes.node,
+  actions: PropTypes.node,
+  children: PropTypes.node.isRequired,
+  fullWidth: PropTypes.bool
+};
+
+DashboardSection.defaultProps = {
+  subtitle: undefined,
+  icon: null,
+  actions: null,
+  fullWidth: false
+};

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,169 +1,51 @@
 :root {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   color: #0f172a;
-  background-color: #f1f5f9;
+  background-color: #e7eff7;
+  --color-blue-600: #1e88e5;
+  --color-blue-400: #42a5f5;
+  --color-green-600: #2e7d32;
+  --color-green-400: #43a047;
+  --color-amber-500: #f59e0b;
+  --color-slate-900: #0f172a;
+  --color-slate-700: #334155;
+  --color-slate-500: #64748b;
+  --color-slate-200: rgba(148, 163, 184, 0.25);
+  --surface-glass: rgba(255, 255, 255, 0.86);
+  --surface-border: rgba(15, 23, 42, 0.08);
 }
 
-body,
 html,
+body,
 #root {
   margin: 0;
   padding: 0;
   min-height: 100vh;
+  background: linear-gradient(180deg, rgba(30, 136, 229, 0.18), rgba(46, 125, 50, 0.12) 45%, rgba(248, 250, 252, 0.9));
 }
 
 a {
   color: inherit;
 }
 
-.app-shell {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
-header {
-  background: linear-gradient(120deg, #2563eb, #10b981);
-  color: white;
-  padding: 1.5rem 2rem;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.15);
-}
-
-header h1 {
-  margin: 0;
-  font-size: 1.8rem;
-}
-
-header p {
-  margin: 0.25rem 0 0;
-  opacity: 0.85;
-}
-
-main {
-  flex: 1;
-  padding: 2rem;
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  align-items: start;
-}
-
-.card {
-  background: white;
-  border-radius: 16px;
-  padding: 1.5rem;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-.card h2 {
-  margin-top: 0;
-  font-size: 1.25rem;
-}
-
-.summary-grid {
-  display: grid;
-  gap: 1rem;
-}
-
-.summary-card {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(16, 185, 129, 0.15));
-  border-radius: 12px;
-  padding: 1rem 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.summary-card strong {
-  font-size: 1.1rem;
-}
-
-.dataset-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.dataset-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background: rgba(15, 23, 42, 0.03);
-  border-radius: 10px;
-  padding: 0.75rem 1rem;
-}
-
-.dataset-item span.kind {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  color: #475569;
-  letter-spacing: 0.06em;
-}
-
-.charts-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1.5rem;
-}
-
-.leaflet-container {
-  width: 100%;
-  height: 320px;
-  border-radius: 12px;
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
-}
-
-.table-wrapper {
-  max-height: 320px;
-  overflow: auto;
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.9rem;
-}
-
-thead {
-  position: sticky;
-  top: 0;
-  background: #e2e8f0;
-}
-
-th,
-td {
-  padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
-  text-align: left;
-}
-
-.status {
-  font-size: 0.85rem;
-  color: #475569;
-}
-
-.error {
-  color: #dc2626;
-}
-
 button {
-  background: linear-gradient(120deg, #2563eb, #6366f1);
+  background: linear-gradient(120deg, var(--color-blue-600), var(--color-green-600));
   border: none;
   color: white;
-  padding: 0.5rem 1rem;
+  padding: 0.6rem 1.25rem;
   border-radius: 999px;
   cursor: pointer;
   font-weight: 600;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 button:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 6px 12px rgba(79, 70, 229, 0.3);
+  box-shadow: 0 12px 24px rgba(30, 136, 229, 0.25);
 }
 
 button:disabled {
@@ -171,58 +53,382 @@ button:disabled {
   cursor: not-allowed;
 }
 
-.menu-list {
-  list-style: none;
-  padding: 0;
+.button--ghost {
+  background: transparent;
+  border: 1px solid rgba(30, 136, 229, 0.35);
+  color: var(--color-blue-600);
+  box-shadow: none;
+}
+
+.button--ghost:hover:not(:disabled) {
+  background: rgba(30, 136, 229, 0.08);
+  transform: none;
+}
+
+.status {
+  font-size: 0.9rem;
+  color: var(--color-slate-500);
+}
+
+.status--error {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.status.status--error {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.status.status--error p {
   margin: 0;
+}
+
+.dashboard-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  color: var(--color-slate-900);
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.75rem 3rem;
+  background: linear-gradient(115deg, rgba(30, 136, 229, 0.95), rgba(46, 125, 50, 0.92));
+  color: white;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
+}
+
+.dashboard-header__brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.dashboard-header__logo {
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0.55));
+  display: grid;
+  place-items: center;
+  color: white;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+}
+
+.dashboard-header__brand h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: -0.01em;
+}
+
+.dashboard-header__brand p {
+  margin: 0.15rem 0 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.dashboard-header__nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.dashboard-header__nav-item {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: white;
+  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+}
+
+.dashboard-header__nav-item:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.dashboard-main {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.hero-panel {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(224, 242, 254, 0.85));
+  border-radius: 32px;
+  padding: 2.5rem;
+  border: 1px solid rgba(30, 136, 229, 0.15);
+  box-shadow: 0 24px 60px rgba(30, 136, 229, 0.16);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+  position: relative;
+}
+
+.hero-panel__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  max-width: 560px;
+}
+
+.hero-panel__content h2 {
+  margin: 0;
+  font-size: 2rem;
+  letter-spacing: -0.015em;
+}
+
+.hero-panel__content p {
+  margin: 0;
+  color: var(--color-slate-500);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.hero-panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hero-panel__status {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+}
+
+.hero-panel__status-card {
+  background: linear-gradient(135deg, rgba(46, 125, 50, 0.9), rgba(30, 136, 229, 0.9));
+  color: white;
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(30, 136, 229, 0.25);
+  min-width: 220px;
+}
+
+.hero-panel__status-label {
+  font-size: 0.85rem;
+  opacity: 0.9;
+  margin: 0 0 0.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-panel__status-value {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.hero-panel__status-hint {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+.hero-panel__stats {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.hero-panel__stat {
+  min-width: 0;
+}
+
+.stat-card {
+  display: flex;
+  gap: 0.9rem;
+  align-items: center;
+  border-radius: 20px;
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+}
+
+.stat-card__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-size: 1.2rem;
+  color: white;
+}
+
+.stat-card__label {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-slate-500);
+}
+
+.stat-card__value {
+  margin: 0.15rem 0 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.stat-card__hint {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--color-slate-500);
+}
+
+.stat-card--emerald {
+  background: linear-gradient(140deg, rgba(67, 160, 71, 0.14), rgba(224, 247, 250, 0.72));
+}
+
+.stat-card--emerald .stat-card__icon {
+  background: linear-gradient(135deg, #2e7d32, #43a047);
+}
+
+.stat-card--sky {
+  background: linear-gradient(140deg, rgba(66, 165, 245, 0.16), rgba(240, 249, 255, 0.78));
+}
+
+.stat-card--sky .stat-card__icon {
+  background: linear-gradient(135deg, #1e88e5, #42a5f5);
+}
+
+.stat-card--slate {
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.12), rgba(226, 232, 240, 0.75));
+}
+
+.stat-card--slate .stat-card__icon {
+  background: linear-gradient(135deg, #1f2937, #334155);
+}
+
+.stat-card--amber {
+  background: linear-gradient(140deg, rgba(245, 158, 11, 0.16), rgba(254, 243, 199, 0.75));
+}
+
+.stat-card--amber .stat-card__icon {
+  background: linear-gradient(135deg, #f59e0b, #facc15);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.dashboard-section {
+  background: var(--surface-glass);
+  border-radius: 24px;
+  padding: 1.75rem;
+  border: 1px solid var(--surface-border);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.dashboard-section--wide {
+  grid-column: 1 / -1;
+}
+
+.dashboard-section__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.dashboard-section__title {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.dashboard-section__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(30, 136, 229, 0.15), rgba(46, 125, 50, 0.15));
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+}
+
+.dashboard-section__title h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.dashboard-section__title p {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--color-slate-500);
+}
+
+.dashboard-section__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.dashboard-section__content {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.menu-list li {
-  background: rgba(15, 23, 42, 0.04);
-  border-radius: 12px;
-  padding: 1rem 1.25rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-.menu-item-head {
+.section-actions {
   display: flex;
-  align-items: baseline;
+  flex-wrap: wrap;
   gap: 0.5rem;
-  font-weight: 600;
-  color: #1e293b;
 }
 
-.menu-key {
-  font-family: 'JetBrains Mono', 'Fira Code', monospace;
-  color: #2563eb;
+.icon-circle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(30, 136, 229, 0.12);
 }
 
-.menu-label {
-  font-size: 1.05rem;
+.table-wrapper {
+  max-height: 340px;
+  overflow: auto;
+  border-radius: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.9);
 }
 
-.menu-params {
-  margin: 0.75rem 0 0;
-  padding-left: 1rem;
-  color: #475569;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
 }
 
-.menu-params li {
-  list-style: disc;
+thead {
+  position: sticky;
+  top: 0;
+  background: rgba(30, 136, 229, 0.08);
 }
 
-.menu-params code {
-  background: rgba(37, 99, 235, 0.12);
-  border-radius: 6px;
-  padding: 0.1rem 0.4rem;
-  margin-right: 0.35rem;
-  font-size: 0.85rem;
+th,
+td {
+  padding: 0.65rem 0.85rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+  text-align: left;
 }
 
 .plot-controls {
@@ -230,7 +436,6 @@ button:disabled {
   flex-wrap: wrap;
   gap: 1rem;
   align-items: flex-end;
-  margin-bottom: 1.25rem;
 }
 
 .plot-controls label {
@@ -238,21 +443,21 @@ button:disabled {
   flex-direction: column;
   gap: 0.35rem;
   font-size: 0.9rem;
-  color: #334155;
+  color: var(--color-slate-700);
 }
 
 .plot-controls select,
 .plot-controls input {
-  border: 1px solid rgba(148, 163, 184, 0.6);
-  border-radius: 8px;
-  padding: 0.4rem 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  border-radius: 10px;
+  padding: 0.45rem 0.65rem;
   font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.9);
 }
 
 .plot-actions {
   display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+  gap: 0.65rem;
 }
 
 .plot-gallery {
@@ -262,18 +467,18 @@ button:disabled {
 }
 
 .plot-item {
-  background: rgba(15, 23, 42, 0.03);
-  border-radius: 12px;
-  padding: 0.75rem;
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 16px;
+  padding: 0.85rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
   border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .plot-item img {
   width: 100%;
-  border-radius: 8px;
+  border-radius: 12px;
   object-fit: cover;
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
 }
@@ -281,35 +486,104 @@ button:disabled {
 .plot-item figcaption {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.25rem;
   font-size: 0.85rem;
-  color: #475569;
+  color: var(--color-slate-500);
 }
 
 .plot-item figcaption strong {
   font-size: 0.95rem;
-  color: #1e293b;
+  color: var(--color-slate-700);
 }
 
-@media (max-width: 768px) {
-  main {
-    grid-template-columns: 1fr;
-  }
+.menu-actions {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.menu-actions__item {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 20px;
+  padding: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.menu-actions__item header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+}
+
+.menu-actions__item h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.menu-actions__key {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  background: rgba(30, 136, 229, 0.1);
+  color: var(--color-blue-600);
+  border-radius: 8px;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.85rem;
+}
+
+.menu-actions__params {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.menu-actions__params li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.85rem;
+  color: var(--color-slate-500);
+}
+
+.menu-actions__params code {
+  background: rgba(30, 136, 229, 0.1);
+  border-radius: 6px;
+  padding: 0.1rem 0.4rem;
+  font-size: 0.8rem;
+}
+
+.menu-actions__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.leaflet-container {
+  width: 100%;
+  height: 320px;
+  border-radius: 18px;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
 }
 
 .prediction-panel {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
 .prediction-meta {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
-  background: rgba(37, 99, 235, 0.08);
-  border-radius: 0.75rem;
-  padding: 1rem;
+  background: rgba(30, 136, 229, 0.08);
+  border-radius: 18px;
+  padding: 1.25rem;
+  border: 1px solid rgba(30, 136, 229, 0.15);
 }
 
 .prediction-stat {
@@ -318,64 +592,52 @@ button:disabled {
   min-width: 140px;
 }
 
-.prediction-stat .label {
-  font-size: 0.78rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(15, 23, 42, 0.6);
-  margin-bottom: 0.2rem;
-}
-
-.prediction-stat strong {
-  font-size: 1.05rem;
-}
-
 .prediction-actions {
   display: flex;
   justify-content: flex-end;
 }
 
 .prediction-section {
-  background: rgba(148, 163, 184, 0.1);
-  border-radius: 0.75rem;
-  padding: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 16px;
+  padding: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-}
-
-.prediction-section h3 {
-  margin: 0;
-  font-size: 1.1rem;
-  color: #0f172a;
-}
-
-.chart-tooltip {
-  background: white;
-  border-radius: 0.5rem;
-  box-shadow: 0 10px 35px -12px rgba(15, 23, 42, 0.4);
-  padding: 0.75rem 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-}
-
-.chart-tooltip strong {
-  display: block;
-  margin-bottom: 0.35rem;
-  color: #1f2937;
-}
-
-.chart-tooltip ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.chart-tooltip li {
-  display: flex;
-  justify-content: space-between;
   gap: 1rem;
+}
+
+.dashboard-footer {
+  margin-top: auto;
+  padding: 2rem 1rem 3rem;
+  text-align: center;
   font-size: 0.85rem;
+  color: var(--color-slate-500);
+}
+
+@media (max-width: 900px) {
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.25rem;
+  }
+
+  .dashboard-header__nav {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .hero-panel {
+    padding: 2rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-main {
+    padding: 2.5rem 1.25rem 3rem;
+  }
+
+  .hero-panel__actions {
+    flex-direction: column;
+  }
 }


### PR DESCRIPTION
## Summary
- restructure the main dashboard view with modular layout sections, hero panel, and menu actions adapted to the existing blue/green theme
- add reusable stat cards and layout utilities to highlight bloom metrics while reusing existing charts, tables, and prediction panels
- refresh global styling to match the project palette and ignore frontend build artifacts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5797963748324bc6f3874e19b6b0d